### PR TITLE
gRPC deps

### DIFF
--- a/abseil-cpp/abseil-cpp.spec
+++ b/abseil-cpp/abseil-cpp.spec
@@ -1,0 +1,263 @@
+#
+# spec file for package abseil-cpp
+#
+# Copyright (c) 2022 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%define lname	libabsl2206_0_0
+Name:           abseil-cpp
+Version:        20220623.1
+Release:        1.1
+Summary:        C++11 libraries which augment the C++ stdlib
+License:        Apache-2.0
+URL:            https://abseil.io/
+Source0:        https://github.com/abseil/abseil-cpp/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# PATCH-FIX-OPENSUSE options-{old,cxx17}.patch Ensure ABI stability regardless of compiler options
+%if 0%{?suse_version} < 1550
+#Patch0:         options-old.patch
+%else
+#Patch0:         options-cxx17.patch
+%endif
+# PATCH-FIX-UPSTREAM Fix-maes-msse41-leaking-into-pkgconfig.patch
+#Patch1:         Fix-maes-msse41-leaking-into-pkgconfig.patch
+Patch2:          fe6ec8efabe2ca1f6d68d6c14087cdd58ea07136.patch
+
+%description
+Abseil is a collection of C++11 libraries which augment the C++
+standard library. It also provides features incorporated into C++14
+and C++17 standards.
+
+%package -n %{lname}
+Summary:        C++11 libraries which augment the C++ stdlib
+Obsoletes:      abseil-cpp < %{version}-%{release}
+Provides:       abseil-cpp = %{version}-%{release}
+
+%description -n %{lname}
+Abseil is a collection of C++11 libraries which augment the C++
+standard library. It also provides features incorporated into C++14
+and C++17 standards.
+
+%package devel
+Summary:        Header files for Abseil
+Requires:       %{lname} = %{version}
+
+%description devel
+Abseil is a collection of C++11 libraries which augment the C++
+standard library.
+This package contains headers and build system files for it.
+
+%prep
+%autosetup -p1
+
+%build
+
+mkdir cmake-build
+cd cmake-build
+
+# absl/status/status.cc needs _LINUX_SOURCE_COMPAT
+export CXXFLAGS="-pthread -fno-extern-tls-init -D_LINUX_SOURCE_COMPAT"
+export LDFLAGS="-pthread"
+
+# XXX: USEPCRE?
+cmake .. \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX=%{_prefix} \
+	-DBUILD_SHARED_LIBS:BOOL=On \
+	-DCMAKE_CXX_STANDARD=11 \
+	#
+%make_build
+
+%install
+
+cd cmake-build
+%make_install
+
+%files -n %{lname}
+%defattr(-, qsys, *none)
+%license LICENSE
+%{_libdir}/libabsl_*.so.*
+
+%files devel
+%defattr(-, qsys, *none)
+%doc README.md
+%{_includedir}/absl
+%{_libdir}/cmake/absl
+%{_libdir}/libabsl_*.so
+%{_libdir}/pkgconfig/absl_*.pc
+
+%changelog
+* Wed Jan 18 2023 Calvin Buckley <calvin@seidengroup.com>
+- port to IBM i
+* Sat Sep 24 2022 Dirk Müller <dmueller@suse.com>
+- update to 20220623.1:
+  * minor warning fix
+* Mon Jul 11 2022 Bruno Pitrus <brunopitrus@hotmail.com>
+- Add Fix-maes-msse41-leaking-into-pkgconfig.patch
+  * Do not make programs compiled with abseil require new-ish CPUs.
+* Sun Jul  3 2022 Matthias Eliasson <elimat@opensuse.org>
+- Update to version 20220623.0
+  What's New:
+  * Added absl::AnyInvocable, a move-only function type.
+  * Added absl::CordBuffer, a type for buffering data for eventual inclusion an
+    absl::Cord, which is useful for writing zero-copy code.
+  * Added support for command-line flags of type absl::optional<T>.
+  Breaking Changes:
+  * CMake builds now use the flag ABSL_BUILD_TESTING (default: OFF) to control
+    whether or not unit tests are built.
+  * The ABSL_DEPRECATED macro now works with the GCC compiler. GCC users that
+    are experiencing new warnings can use -Wno-deprecated-declatations silence
+  the warnings or use -Wno-error=deprecated-declarations to see warnings but
+  not fail the build.
+  * ABSL_CONST_INIT uses the C++20 keyword constinit when available. Some
+    compilers are more strict about where this keyword must appear compared to
+  the pre-C++20 implementation.
+  * Bazel builds now depend on the bazelbuild/bazel-skylib repository.
+    See Abseil's WORKSPACE file for an example of how to add this dependency.
+  Other:
+  * This will be the last release to support C++11. Future releases will require at least C++14.
+- run spec-cleaner
+* Wed Jun 29 2022 Fabian Vogt <fvogt@suse.com>
+- Remove obsolete 0%%{suse_version} < 1500 conditions
+* Wed Jun 29 2022 Bruno Pitrus <brunopitrus@hotmail.com>
+- Add options-old.patch, options-cxx17.patch
+  * Ensure ABI stability regardless of compiler settings per instruction in the header.
+* Mon Apr  4 2022 Jan Engelhardt <jengelh@inai.de>
+- Implement shlib packaging policy
+* Fri Mar  4 2022 Danilo Spinella <danilo.spinella@suse.com>
+- Fix build on SLE-12-SP5
+* Tue Jan  4 2022 Dirk Müller <dmueller@suse.com>
+- update to 20211102.0:
+  * absl::Cord is now implemented as a b-tree. The new implementation offers
+    improved performance in most workloads.
+  * absl::SimpleHexAtoi() has been added to strings library for parsing
+    hexadecimal strings
+* Wed Jun 30 2021 Ferdinand Thiessen <rpm@fthiessen.de>
+- Update to version 20210324.2 (LTS):
+  * No user visible changes, only build system related
+* Sun Apr 25 2021 Ferdinand Thiessen <rpm@fthiessen.de>
+- Update to LTS version 20210324.1
+  * Fixed missing absl::Cleanup
+  * Fixed pkgconfig install path
+- Dropped upstream merged Correctly-install-pkgconfig.patch
+* Tue Apr 13 2021 Ferdinand Thiessen <rpm@fthiessen.de>
+- Update to LTS version 20210324.0
+  * Breaking: The empty absl::container target has been removed from
+    the CMake build. This target had no effect and references to
+    this target in user code can safely be removed.
+  * New: The cleanup library has been released. This library contains
+    the control-flow-construct-like type absl::Cleanup which is used
+    for executing a callback on scope exit.
+  * New: The numeric library now includes bits.h, a polyfill header
+    containing implementations of C++20's bitwise math functions.
+  * New: Abseil now installs pkg-config files to make it easier to
+    use Abseil with some other build systems.
+  * New: Abseil now respects the default CMake installation paths.
+    Standard CMake variables like CMAKE_INSTALL_PREFIX can be used
+    to change the installation path.
+- Added Correctly-install-pkgconfig.patch from upstream to fix
+  installation of pkgconfig files
+- Call ldconfig on post and postun
+* Tue Dec 29 2020 Matthias Eliasson <elimat@opensuse.org>
+- Update to version 20200923.2
+  What's New:
+  * absl::StatusOr<T> has been released. See our blog
+    post for more information.
+  * Abseil Flags reflection interfaces have been released.
+  * Abseil Flags memory usage has been significantly optimized.
+  * Abseil now supports a "hardened" build mode. This build mode enables
+    runtime checks that guard against programming errors that may lead
+    to security vulnerabilities.
+  Notable Fixes:
+  * Sanitizer dynamic annotations like AnnotateRWLockCreate that are
+    also defined by the compiler sanitizer implementation are no longer
+    also defined by Abseil.
+  * Sanitizer macros are now prefixed with ABSL_ to avoid naming collisions.
+  * Sanitizer usage is now automatically detected and no longer requires
+    macros like ADDRESS_SANITIZER to be defined on the command line.
+  Breaking Changes:
+  * Abseil no longer contains a dynamic_annotations library. Users
+    using a supported build system (Bazel or CMake) are unaffected by
+    this, but users manually specifying link libraries may get an error
+    about a missing linker input.
+* Fri Nov  6 2020 Fabian Vogt <fvogt@suse.com>
+- Drop source package, was only used by grpc which was switched
+  over to use the shared library
+* Tue Oct 27 2020 Jan Engelhardt <jengelh@inai.de>
+- Build shared libraries of abseil for use by grpc
+  (related to https://github.com/grpc/grpc/issues/24476)
+* Sat Sep  5 2020 Jan Engelhardt <jengelh@inai.de>
+- Switch the package to noarch.
+* Fri Jul 24 2020 Matthias Eliasson <elimat@opensuse.org>
+- Update to version 20200225.2
+  * This release fixes the list of dependencies of absl::Cord in the CMake build.
+  * bug fix for absl::Status::ErasePayload
+* Thu Jan 16 2020 Michał Rostecki <mrostecki@opensuse.org>
+- Remove all packages except source.
+* Tue Jan 14 2020 Dominique Leuenberger <dimstar@opensuse.org>
+- Set ExcludeArch: %%ix86: bazel is required to build which in turn
+  is not supported on ix86.
+* Wed Dec 18 2019 Swaminathan Vasudevan <svasudevan@suse.com>
+- Update to version 20190808
+* Sat Nov 23 2019 Bernhard Wiedemann <bwiedemann@suse.com>
+- Sort find output to make build reproducible (boo#1041090)
+* Thu Oct 17 2019 Richard Brown <rbrown@suse.com>
+- Remove obsolete Groups tag (fate#326485)
+* Mon Sep 23 2019 mrostecki@opensuse.org
+- Update to version 20190605:
+  * avoid use of undefined ABSL_HAVE_ELF_MEM_IMAGE
+  * Avoid undefined behavior when nullptr is passed to memcpy with size 0
+  * CMake: Set correct flags for clang-cl
+  * Adding linking of CoreFoundation to CMakeLists in absl/time as
+    time_zone_lookup.cc includes CoreFoundation
+  * Implement Span::first and Span::last from C++20
+  * Changed HTTP URLs to HTTPS where possible
+  * Fix GCC8 warnings
+  * Fix library order for Conan package
+  * _umul128 is not available on Windows ARM64
+  * Add note at top that this is supported best-effort
+  * Update Conan author
+  * Add Conan topics
+  * Remove cctz as external dependency
+  * Add Conan recipe
+* Thu Sep 19 2019 Michał Rostecki <mrostecki@opensuse.org>
+- Add source package.
+* Wed Jul 24 2019 Michał Rostecki <mrostecki@opensuse.org>
+- Use bazel0.19 as build fails with the latest bazel (0.26)
+* Thu Mar  7 2019 Michal Rostecki <mrostecki@opensuse.org>
+- Add soname to all *.so* files.
+* Thu Feb 28 2019 Michał Rostecki <mrostecki@opensuse.org>
+- Fix build with Bazel 0.22.0.
+- Add optflags.
+* Fri Jan 18 2019 Guillaume GARDET <guillaume.gardet@opensuse.org>
+- Fix aarch64 and ppc64 builds
+* Wed Dec 12 2018 Jan Engelhardt <jengelh@inai.de>
+- Trim redundancies from description.
+* Thu Nov 29 2018 Michał Rostecki <mrostecki@suse.de>
+- Update to version 20181127:
+  * Export of internal Abseil changes. -- 15d7bcf28220750db46930f4d8c090b54e3ae5fe by Jon Cohen <cohenjon@google.com>:
+  * Export of internal Abseil changes. -- 5278e56bd7d322ecf161eaf29fd7fa3941d7431b by Greg Falcon <gfalcon@google.com>:
+- Switch from CMake to Bazel
+* Mon Nov 19 2018 Michał Rostecki <mrostecki@suse.de>
+- Update to version 20181116:
+  * Export of internal Abseil changes. -- da04b8cd21f6225d71397471474d34a77df0efd6 by Jon Cohen <cohenjon@google.com>:
+  * Export of internal Abseil changes. -- 5f1ab09522226336830d9ea6ef7276d37f536ac5 by Abseil Team <absl-team@google.com>:
+  * Export of internal Abseil changes. -- 07575526242a8e1275ac4223a3d2822795f46569 by CJ Johnson <johnsoncj@google.com>:
+  * Export of internal Abseil changes. -- 178e7a9a76fc8fcd6df6335b59139cbe644a16b9 by Jon Cohen <cohenjon@google.com>:
+  * Export of internal Abseil changes. -- ee19e203eca970ff88e8f25ce4e19c32e143b988 by Jon Cohen <cohenjon@google.com>:
+  * Export of internal Abseil changes. -- 4e224c85c3730398919fc5195cb1fc7a752e6e4f by Mark Barolak <mbar@google.com>:
+  * Export of internal Abseil changes. -- 9e8aa654630015ea8221703b0ea10dd1a47a848f by Abseil Team <absl-team@google.com>:
+  * Export of internal Abseil changes. -- ba4dd47492748bd630462eb68b7959037fc6a11a by Abseil Team <absl-team@google.com>:
+  * Fix compilation of generic byteswap routines
+  * Fix absl::container on VS2017 v15.8 (#192)

--- a/abseil-cpp/fe6ec8efabe2ca1f6d68d6c14087cdd58ea07136.patch
+++ b/abseil-cpp/fe6ec8efabe2ca1f6d68d6c14087cdd58ea07136.patch
@@ -1,0 +1,40 @@
+From fe6ec8efabe2ca1f6d68d6c14087cdd58ea07136 Mon Sep 17 00:00:00 2001
+From: Derek Mauro <dmauro@google.com>
+Date: Thu, 19 Jan 2023 07:33:56 -0800
+Subject: [PATCH] Only enable cordz on Linux with thread_local support
+
+Fixes #1365
+
+PiperOrigin-RevId: 503160321
+Change-Id: I210f194373c3e08a75d68298a8482be5f1f2227c
+---
+ absl/strings/internal/cordz_functions.h | 16 ++++------------
+ 1 file changed, 4 insertions(+), 12 deletions(-)
+
+diff --git a/absl/strings/internal/cordz_functions.h b/absl/strings/internal/cordz_functions.h
+index 93f46ec6fe..ed108bf1b4 100644
+--- a/absl/strings/internal/cordz_functions.h
++++ b/absl/strings/internal/cordz_functions.h
+@@ -32,18 +32,10 @@ int32_t get_cordz_mean_interval();
+ // Sets the sample rate with the average interval between samples.
+ void set_cordz_mean_interval(int32_t mean_interval);
+ 
+-// Enable cordz unless any of the following applies:
+-// - no thread local support
+-// - MSVC build
+-// - Android build
+-// - Apple build
+-// - DLL build
+-// Hashtablez is turned off completely in opensource builds.
+-// MSVC's static atomics are dynamically initialized in debug mode, which breaks
+-// sampling.
+-#if defined(ABSL_HAVE_THREAD_LOCAL) && !defined(_MSC_VER)  && \
+-    !defined(ABSL_BUILD_DLL) && !defined(ABSL_CONSUME_DLL) && \
+-    !defined(__ANDROID__) && !defined(__APPLE__)
++// Cordz is only enabled on Linux with thread_local support.
++#if defined(ABSL_INTERNAL_CORDZ_ENABLED)
++#error ABSL_INTERNAL_CORDZ_ENABLED cannot be set directly
++#elif defined(__linux__) && defined(ABSL_HAVE_THREAD_LOCAL)
+ #define ABSL_INTERNAL_CORDZ_ENABLED 1
+ #endif
+ 

--- a/re2/re2.spec
+++ b/re2/re2.spec
@@ -1,0 +1,311 @@
+#
+# spec file for package re2
+#
+# Copyright (c) 2022 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%global longver 2022-12-01
+%global shortver %(echo %{longver}|sed 's|-||g')
+%define libname libre2-10
+Name:           re2
+Version:        %{shortver}
+Release:        50.1
+Summary:        C++ fast alternative to backtracking RE engines
+License:        BSD-3-Clause
+Group:          Development/Libraries/C and C++
+URL:            https://github.com/google/re2
+Source0:        %{url}/archive/%{longver}/%{name}-%{longver}.tar.gz
+BuildRequires:  cmake >= 3.10.2
+
+%description
+RE2 is a C++ library providing a fast, safe, thread-friendly alternative to
+backtracking regular expression engines like those used in PCRE, Perl, and
+Python.
+
+Backtracking engines are typically full of features and convenient syntactic
+sugar but can be forced into taking exponential amounts of time on even small
+inputs.
+
+In contrast, RE2 uses automata theory to guarantee that regular expression
+searches run in time linear in the size of the input, at the expense of some
+missing features (e.g. back references and generalized assertions).
+
+%package -n %{libname}
+Summary:        C++ fast alternative to backtracking RE engines
+Group:          System/Libraries
+
+%description -n %{libname}
+RE2 is a C++ library providing a fast, safe, thread-friendly alternative to
+backtracking regular expression engines like those used in PCRE, Perl, and
+Python.
+
+Backtracking engines are typically full of features and convenient syntactic
+sugar but can be forced into taking exponential amounts of time on even small
+inputs.
+
+In contrast, RE2 uses automata theory to guarantee that regular expression
+searches run in time linear in the size of the input, at the expense of some
+missing features (e.g. back references and generalized assertions).
+
+%package        devel
+Summary:        C++ header files and library symbolic links for %{name}
+Group:          Development/Libraries/C and C++
+Requires:       %{libname} = %{version}
+
+%description    devel
+This package contains the C++ header files and symbolic links to the shared
+libraries for %{name}. If you would like to develop programs using %{name},
+you will need to install %{name}-devel.
+
+%prep
+%autosetup -n %{name}-%{longver}
+
+%build
+
+mkdir cmake-build
+cd cmake-build
+
+export CXXFLAGS="-pthread -fno-extern-tls-init"
+export LDFLAGS="-pthread"
+
+# XXX: USEPCRE?
+cmake .. \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX=%{_prefix} \
+	-DBUILD_SHARED_LIBS:BOOL=On
+	#
+#cmake_build
+%make_build
+
+%install
+
+cd cmake-build
+#cmake_install
+%make_install
+
+%check
+# Test if created library is installed correctly
+%make_build shared-testinstall DESTDIR=%{buildroot} includedir=%{_includedir} libdir=%{_libdir}
+%if %{with test}
+# Actual functionality tests
+#export LD_LIBRARY_PATH=%{buildroot}/%{_libdir}:LD_LIBRARY_PATH
+%ctest --repeat until-pass:9
+%endif
+
+%files -n %{libname}
+%defattr(-, qsys, *none)
+%license LICENSE
+%doc AUTHORS CONTRIBUTORS README
+%{_libdir}/lib%{name}.so.*
+
+%files devel
+%defattr(-, qsys, *none)
+%license LICENSE
+%{_includedir}/%{name}
+%{_libdir}/lib%{name}.so
+%{_libdir}/pkgconfig/%{name}.pc
+%{_libdir}/cmake/%{name}
+
+%changelog
+* Wed Jan 18 2023 Calvin Buckley <calvin@seidengroup.com>
+- port to IBM i
+* Sun Dec  4 2022 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2022-12-01:
+  * Update to Unicode 15.0.0 data
+  * cmake install now installs the pkg-config file
+* Wed Jun  1 2022 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2022-06-01:
+  * switch to cxx_std_11 and other developer visible fixes
+* Sun May  1 2022 Callum Farmer <gmbr3@opensuse.org>
+- Use Release config so O3 is used
+* Thu Apr 28 2022 Callum Farmer <gmbr3@opensuse.org>
+- Avoid sporadic failures by setting until-pass on CTest
+* Wed Apr 27 2022 Callum Farmer <gmbr3@opensuse.org>
+- Disable tests on ARMv6
+* Tue Apr 26 2022 Callum Farmer <gmbr3@opensuse.org>
+- Disable tests on ZSystems and RISCV
+* Sun Apr 24 2022 Stefan Brüns <stefan.bruens@rwth-aachen.de>
+- Switch build to CMake, otherwise CMake config is not installed.
+  Required for Apache ORC and arrow, and google-or-tools.
+  (https://github.com/google/re2/issues/304)
+- Run some real tests via CTest
+* Fri Apr  1 2022 Andreas Stieger <andreas.stieger@gmx.de>
+- Update to 2022-04-01:
+  * Improve performance slightly
+  * Prog::Fangout() is no longer experimental
+* Fri Feb  4 2022 Callum Farmer <gmbr3@opensuse.org>
+- Update to 2022-02-01:
+  * Address a `-Wunused-but-set-variable' warning from Clang 13.x
+  * Don't specify the -std flag in Makefile or re2.pc
+  * Remove a redundant map access
+* Sun Dec  5 2021 Callum Farmer <gmbr3@opensuse.org>
+- Use newer libs and GCC on Leap 15.3 & 15.4
+* Fri Nov  5 2021 Callum Farmer <gmbr3@opensuse.org>
+- Update to 2021-11-01:
+  * Update Unicode data to 14.0.0
+  * Address a `-Wshadow' warning
+* Wed Sep  1 2021 Callum Farmer <gmbr3@opensuse.org>
+- Update to 2021-09-01:
+  * Permit Unicode characters beyond ASCII in capture names
+* Fri Aug  6 2021 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2021-08-01:
+  * case-insensitive prefix acceleration
+* Sat Jun 12 2021 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2021-06-01:
+  * Fix (|a)* matching more text than (|a)+
+  * build system tweaks and developer visible fixes
+* Thu Apr 15 2021 Andreas Stieger <andreas.stieger@gmx.de>
+- Update to 2021-04-01:
+  * Make cached benchmarks actually use cached objects
+  * Address some -Wmissing-field-initializers warnings
+  * Make it easier to swap in a scalable reaer-writer mutex
+  * In the shared library, set compatibility version and
+    current version
+* Thu Feb  4 2021 Callum Farmer <gmbr3@opensuse.org>
+- Update to version 2021-02-02:
+  * Address `-Wnull-dereference' warnings from GCC 10.x.
+* Thu Nov  5 2020 Callum Farmer <callumjfarmer13@gmail.com>
+- Update to version 2020-11-01:
+  * Refactoring and fixes
+* Sat Oct 10 2020 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2020-10-01:
+  * build system updates and compiler warnings fixes
+* Tue Aug 11 2020 Martin Pluskal <mpluskal@suse.com>
+- Update to version 2020-08-01:
+  * Various internal changes
+* Sun Jun  7 2020 Martin Pluskal <mpluskal@suse.com>
+- Update to version 2020-06-01:
+  * Various internal changes
+* Fri May 29 2020 Martin Pluskal <mpluskal@suse.com>
+- Enable PGO during build
+* Wed May 20 2020 Martin Pluskal <mpluskal@suse.com>
+- Update to version 2020-05-03:
+  * Internal fixes and optimisations
+  * Remove deprecated APIs, SONAME change
+- Build tests with optflags
+- Disable tests for 32 bit architectures
+* Sun Apr  5 2020 Andreas Stieger <andreas.stieger@gmx.de>
+- Updat to version 2020-04-01:
+  * Update Unicode data to 13.0.0
+  * Include the pattern length in "DFA out of memory" errorrs
+* Fri Mar 20 2020 Martin Pluskal <mpluskal@suse.com>
+- Update to version 2020-03-03:
+  * various developer visible changes
+* Thu Feb 13 2020 Martin Pluskal <mpluskal@suse.com>
+- Small spec file update
+* Wed Jan  8 2020 Tomáš Chvátal <tchvatal@suse.com>
+- Update to 2020-01-01:
+  * various developer visible changes
+* Fri Dec  6 2019 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2019-12-01:
+  * fix latent bugs and undefined behavior
+* Sat Nov 16 2019 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2019-11-01:
+  * new benchmark API
+* Thu Sep 12 2019 Andreas Stieger <andreas.stieger@gmx.de>
+- update to 2019-09-01:
+  * build system fixes
+* Fri Aug  2 2019 Andreas Stieger <andreas.stieger@gmx.de>
+- Update to 2019-08-01:
+  * Update Unicode data to 12.1.0
+  * Various developer visible changes
+* Mon Jul 22 2019 Martin Pluskal <mpluskal@suse.com>
+- Fix download url
+* Wed Jul 17 2019 Andreas Stieger <andreas.stieger@gmx.de>
+- Update to 2019-07-01:
+  * developer visible changes
+* Wed Mar 13 2019 Tomáš Chvátal <tchvatal@suse.com>
+- Update to 2019-03-01:
+  * developer visible changes only
+* Fri Jan  4 2019 astieger@suse.com
+- update to 2019-01-01:
+  * developer visible changes, performance tweaks and bug fixes
+* Wed Oct 17 2018 Martin Pluskal <mpluskal@suse.com>
+- update to 2018-10-01:
+  * developer visible changes only
+* Wed Sep  5 2018 astieger@suse.com
+- update to 2018-09-01:
+  * developer visible changes only
+* Thu Aug 23 2018 astieger@suse.com
+- update to 2018-08-01:
+  * Fix the "DFA out of memory" error for the reverse Prog
+* Fri Jul 20 2018 mpluskal@suse.com
+- Simplify spec file a bit
+* Fri Jul 20 2018 astieger@suse.com
+- update to 2018-07-01:
+  * Fix a "DFA out of memory" error
+  * Update Unicode data to 11.0.0
+  * Fix `-Wclass-memaccess' warnings and fallthrough macros
+  * Use the standard first-byte analysis for the DFA too
+* Fri Apr  6 2018 mpluskal@suse.com
+- Update to version 2018-04-01
+  * developer visible changes only
+* Wed Mar 21 2018 astieger@suse.com
+- update to 2018-03-01:
+  * no longer linking against librd and libm
+  * other developer visible changes
+* Fri Feb  2 2018 astieger@suse.com
+- update to 2018-02-01:
+  * developer visible changes only
+* Wed Jan  3 2018 mpluskal@suse.com
+- Update to version 2018-01-01
+  * No upstream changelog available
+* Wed Jan  3 2018 dimstar@opensuse.org
+- Add baselibs.conf: create libre2-0-32bit, dependency to
+  libqt5-qtwebengine-32bit.
+* Mon Dec 18 2017 mpluskal@suse.com
+- Update to version 2017-12-01
+  * No upstream changelog available
+* Fri Nov  3 2017 mpluskal@suse.com
+- Update to version 2017-11-01
+  * No upstream changelog available
+* Mon Sep  4 2017 mpluskal@suse.com
+- Update to version 2017-07-01
+  * No upstream changelog available
+* Sat Jul 29 2017 mpluskal@suse.com
+- Update to version 2017-07-01
+  * No upstream changelog available
+* Sun Jun 11 2017 mpluskal@suse.com
+- Update to version 2017-06-01
+  * No upstream changelog available
+* Fri May 19 2017 vsistek@suse.com
+- Update to version 2017-05-01
+  * No upstream changelog available
+* Thu Apr 13 2017 mpluskal@suse.com
+- Update to version 2017-04-01
+  * No upstream changelog available
+* Thu Mar 16 2017 mpluskal@suse.com
+- Update to version 2017-03-01
+  * No upstream changelog available
+* Sat Jan 14 2017 mpluskal@suse.com
+- Update to version 2017-01-01
+  * No upstream changelog available
+* Sat Dec  3 2016 mpluskal@suse.com
+- Update to version 2016-11-01:
+  * No upstream changelog available
+- Drop no longer needed re2-gcc61.patch
+* Sat Oct 22 2016 jengelh@inai.de
+- Fixup group and avoid rm indirection
+* Thu Sep  8 2016 mpluskal@suse.com
+- Drop releasenumber
+* Wed Sep  7 2016 tchvatal@suse.com
+- Version update to 2016-09-01 version
+  * Various changes based on google needs, long changelog in upstream
+    github repo
+- Rebase spec on Fedora package
+- Add patch to build with gcc 6.1:
+  * re2-gcc61.patch
+* Fri Dec 21 2012 aplanas@novell.com
+- Initial package version.


### PR DESCRIPTION
These are extracted so you can use `GRPC_PYTHON_BUILD_SYSTEM_ABSL=1 GRPC_PYTHON_BUILD_SYSTEM_RE2=1` in an attempt to lower the size of the binaries to make the linker happy.

FWIW my command-line was `GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ABSL=1 GRPC_PYTHON_BUILD_SYSTEM_RE2=1 GRPC_PYTHON_CFLAGS="-D_LINUX_SOURCE_COMPAT -fno-extern-tls-init -Os" GRPC_PYTHON_CXXFLAGS="-Os -fno-extern-tls-init" GRPC_PYTHON_LDFLAGS="-labsl_base -labsl_hash -labsl_status -labsl_strings -labsl_time -labsl_time_zone -labsl_cord -labsl_hashtablez_sampler -labsl_synchronization -labsl_statusor -labsl_str_format_internal -labsl_random_internal_pool_urbg -labsl_random_seed_sequences -labsl_random_internal_randen_slow -labsl_throw_delegate -labsl_raw_hash_set -labsl_cordz_info -labsl_flags_reflection -labsl_spinlock_wait -labsl_bad_variant_access -labsl_bad_optional_access -labsl_random_internal_randen -Wl,-bnoquiet,-s" GRPC_PYTHON_BUILD_SYSTEM_CARES=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip3 install --upgrade google-cloud-pubsub`

Based on the SUSE specs.